### PR TITLE
Feature: Add option to send webcam snapshot along with the notification. 

### DIFF
--- a/octoprint_smsnotifier/__init__.py
+++ b/octoprint_smsnotifier/__init__.py
@@ -8,7 +8,7 @@ import phonenumbers
 class SMSNotifierPlugin(octoprint.plugin.EventHandlerPlugin,
                           octoprint.plugin.SettingsPlugin,
                           octoprint.plugin.TemplatePlugin):
-    
+
     #~~ SettingsPlugin
 
     def get_settings_defaults(self):
@@ -16,16 +16,17 @@ class SMSNotifierPlugin(octoprint.plugin.EventHandlerPlugin,
         # to support customizable mail server, may need port too
         return dict(
             enabled=False,
+            send_image=False,
             recipient_number="",
             from_number="",
             account_sid="",
             auth_token="",
             printer_name="",
             message_format=dict(
-                body="{printer_name} job complete: {filename} done printing after {elapsed_time}" 
+                body="{printer_name} job complete: {filename} done printing after {elapsed_time}"
             )
         )
-    
+
     def get_settings_version(self):
         return 1
 
@@ -37,41 +38,123 @@ class SMSNotifierPlugin(octoprint.plugin.EventHandlerPlugin,
         ]
 
     #~~ EventPlugin
-    
+
     def on_event(self, event, payload):
         if event != "PrintDone":
             return
-        
+
         if not self._settings.get(['enabled']):
             return
-        
+
+        if self._settings.get(['send_image']):
+            snapshot_url = self._settings.global_get(["webcam", "snapshot"])
+            if snapshot_url:
+                try:
+                    import urllib
+                    snapshot_path, headers = urllib.urlretrieve(snapshot_url)
+                except Exception as e:
+                    self._logger.exception("Exception while fetching snapshot from webcam, sending only a note: {message}".format(
+                        message=str(e)))
+                else:
+                    # ffmpeg can't guess file type it seems
+                    os.rename(snapshot_path, snapshot_path + ".jpg")
+                    snapshot_path += ".jpg"
+                    # flip or rotate as needed
+                    self._process_snapshot(snapshot_path)
+
+                    image = {"upload": snapshot_path}
+                    try:
+                        import requests
+                        response = requests.post('http://uploads.im/api?', files=image)
+                    except Exception as e:
+                        self._logger.exception("Error Uploading image to uploads.im: {message}".format(
+                        message=str(e)))
+                    else:
+                        if self._send_txt(payload, response.json()['data'['img_url']]):
+                            return True
+                    self._logger.warn("Could not send a webcam image, sending only a note")
+                    self._send_txt(payload)
+            self._logger.warn("Could not get a image from the webcam. Is it enabled?")
+            return False
+
+        else:
+            self._send_txt(payload)
+
+    def _send_txt(self, payload, snapshot = False):
+
         filename = os.path.basename(payload["file"])
-        
+
         import datetime
         import octoprint.util
         elapsed_time = octoprint.util.get_formatted_timedelta(datetime.timedelta(seconds=payload["time"]))
 
-        
+        fromnumber = phonenumbers.format_number(phonenumbers.parse(self._settings.get(['from_number']), 'US'), phonenumbers.PhoneNumberFormat.E164)
+
+        for number in self._settings.get(['recipient_number']).split(','):
+            tonumber = phonenumbers.format_number(phonenumbers.parse(number, 'US'), phonenumbers.PhoneNumberFormat.E164)
         tags = {
             'filename': filename,
             'elapsed_time': elapsed_time,
             'printer_name': self._settings.get(["printer_name"])
         }
         message = self._settings.get(["message_format", "body"]).format(**tags)
-        
-        try:
-            client = TwilioRestClient(self._settings.get(['account_sid']), self._settings.get(['auth_token']))
 
-            fromnumber = phonenumbers.format_number(phonenumbers.parse(self._settings.get(['from_number']), 'US'), phonenumbers.PhoneNumberFormat.E164)
-            for number in self._settings.get(['recipient_number']).split(','):
-                tonumber = phonenumbers.format_number(phonenumbers.parse(number, 'US'), phonenumbers.PhoneNumberFormat.E164)
+        client = TwilioRestClient(self._settings.get(['account_sid']), self._settings.get(['auth_token']))
+        if snapshot:
+            try:
                 client.messages.create(to=tonumber,from_=fromnumber,body=message)
+            except Exception as e:
+                # report problem sending sms
+                self._logger.exception("SMS notification error: %s" % (str(e)))
+            else:
+                # report notification was sent
+                self._logger.info("Print notification sent to %s" % (self._settings.get(['recipient_number'])))
+                return True
+
+        try:
+            client.messages.create(to=tonumber,from_=fromnumber,body=message)
         except Exception as e:
             # report problem sending sms
             self._logger.exception("SMS notification error: %s" % (str(e)))
         else:
             # report notification was sent
-            self._logger.info("Print notification sent to %s" % (self._settings.get(['recipient_number'])))     
+            self._logger.info("Print notification sent to %s" % (self._settings.get(['recipient_number'])))
+            return True
+
+        return False
+
+
+    def _process_snapshot(self, snapshot_path, pixfmt="yuv420p"):
+        hflip  = self._settings.global_get_boolean(["webcam", "flipH"])
+        vflip  = self._settings.global_get_boolean(["webcam", "flipV"])
+        rotate = self._settings.global_get_boolean(["webcam", "rotate90"])
+        ffmpeg = self._settings.global_get(["webcam", "ffmpeg"])
+
+        if not ffmpeg or not os.access(ffmpeg, os.X_OK) or (not vflip and not hflip and not rotate):
+            return
+
+        ffmpeg_command = [ffmpeg, "-y", "-i", snapshot_path]
+
+        rotate_params = ["format={}".format(pixfmt)] # workaround for foosel/OctoPrint#1317
+        if rotate:
+            rotate_params.append("transpose=2") # 90 degrees counter clockwise
+        if hflip:
+            rotate_params.append("hflip")       # horizontal flip
+        if vflip:
+            rotate_params.append("vflip")       # vertical flip
+
+        ffmpeg_command += ["-vf", sarge.shell_quote(",".join(rotate_params)), snapshot_path]
+        self._logger.info("Running: {}".format(" ".join(ffmpeg_command)))
+
+        p = sarge.run(ffmpeg_command, stdout=sarge.Capture(), stderr=sarge.Capture())
+        if p.returncode == 0:
+            self._logger.info("Rotated/flipped image with ffmpeg")
+        else:
+            self._logger.warn("Failed to rotate/flip image with ffmpeg, "
+                              "got return code {}: {}, {}".format(p.returncode,
+                                                                  p.stdout.text,
+                                                                  p.stderr.text))
+
 
     def get_update_information(self):
         return dict(

--- a/octoprint_smsnotifier/templates/smsnotifier_settings.jinja2
+++ b/octoprint_smsnotifier/templates/smsnotifier_settings.jinja2
@@ -23,41 +23,51 @@
 			<input type="text" class="input-block-level" data-bind="value: settings.plugins.smsnotifier.recipient_number">
 		</div>
 	</div>
-	
+
 	<h4>{{ _('Twilio Settings') }}</h4>
-	
+
 	<p>{{ _('You can use a free trial twilio account; request your first number and verify you cell phone number and you can send free messages to that number.') }}</p>
-	
+
 	<div class="control-group" title="{{ _('Account SID.') }}">
 		<label class="control-label">{{ _('Account SID') }}</label>
 		<div class="controls">
 			<input type="text" class="input-block-level" data-bind="value: settings.plugins.smsnotifier.account_sid">
-		</div>	
+		</div>
 	</div>
-	
+
 	<div class="control-group" title="{{ _('Auth Token.') }}">
 		<label class="control-label">{{ _('Auth Token') }}</label>
 		<div class="controls">
 			<input type="text" class="input-block-level" data-bind="value: settings.plugins.smsnotifier.auth_token">
-		</div>	
+		</div>
 	</div>
-	
+
 	<div class="control-group" title="{{ _('Twilio Number.') }}">
 		<label class="control-label">{{ _('Twilio Number') }}</label>
 		<div class="controls">
 			<input type="text" class="input-block-level" data-bind="value: settings.plugins.smsnotifier.from_number">
-		</div>	
+		</div>
 	</div>
-	
+
 	<h4>{{ _('Message Content') }}</h4>
-	
+
 	<p>{{ _('The SMS template may contain the tags <code>{filename}</code>, <code>{elapsed_time}</code>, and <code>{printer_name}</code>.') }}</p>
-	
+
 	<div class="control-group" title="{{ _('Content of notification message') }}">
 		<label class="control-label">{{ _('Message') }}</label>
 		<div class="controls">
 			<input type="text" class="input-block-level" data-bind="value: settings.plugins.smsnotifier.message_format.body">
 		</div>
 	</div>
-	
+
+	<div class="control-group">
+      <div class="controls">
+          <label class="checkbox">
+              <input type="checkbox" data-bind="checked: settings.plugins.smsnotifier.send_image">{{ _('Send picture (camera required)') }}
+          </label>
+          <span class="help-block"><span class="label label-warning">{{ _('Warning') }}</span>{% trans %}
+              Due to the way Twilio implements <a href="https://www.twilio.com/docs/quickstart/python/sms/sending-via-rest#send-sms-via-api" target="_blank">sending of picture messages</a>. The snapshot from your camera will be hosted <b>publicly</b> at <a href="http://uploads.im" target="_blank">uploads.im</a>.
+          {% endtrans %}</span>
+      </div>
+  </div>
 </form>

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/anoved/OctoPrint-EmailNotifier"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ['twilio>=6','phonenumbers']
+plugin_requires = ['twilio>=6','phonenumbers','requests']
 
 # Additional package data to install for this plugin. The subfolders "templates", "static" and "translations" will
 # already be installed automatically if they exist.


### PR DESCRIPTION
Fixes #2 (request for this feature)

Adds a new requirement for "requests" package.

I placed your original code in a function. I then added an If at the top of on_event to look to see if the user has enabled snapshot or not. If so we grab an image from the camera, upload to upload.im and send a notification with a picture msg. If at any point in time this fails we fall back on a regular notification. 

Twilio requires the image to be uploaded to a public URL. I'm using upload.im for this purpose. Due to this I have strongly warned the user.

![image](https://user-images.githubusercontent.com/17090999/34923432-d4c9de22-f969-11e7-9aa9-608f684586c4.png)

I have tested this on my printer and it works `OctoPrint 1.3.6 running on OctoPi 0.13.0`. I did not get to test failure of third party services like twillio and uploads.im but logic is in place that should deal with it gracefully. Also added logging where it might be needed. 

```
2018-01-14 20:34:32,392 - octoprint.util.comm - INFO - Finished in 0.037 s.
2018-01-14 20:34:32,407 - octoprint.plugins.smsnotifier - INFO - Taking Snapshot.... Say Cheese!
2018-01-14 20:34:33,553 - octoprint.plugins.smsnotifier - INFO - Processing /tmp/tmpsaaPKx.jpg before uploading.
2018-01-14 20:34:41,434 - octoprint.plugins.smsnotifier - INFO - Snapshot uploaded to to http://sk.uploads.im/T1HbB.jpg
2018-01-14 20:34:42,154 - octoprint.plugins.smsnotifier - INFO - Print notification sent to xxxxxxxx
```
![image](https://user-images.githubusercontent.com/17090999/34923511-a55d745e-f96a-11e7-940f-f58bc32542c6.png)

![image](https://user-images.githubusercontent.com/17090999/34923547-f0d89378-f96a-11e7-8709-baff3fa66fbd.png)

All that is left I think is to increment the version number. Wasn't sure what you wanted. "0.3.0"? 
