### PR TITLE
Bugfix: uploads.im is down.

### DIFF
--- a/octoprint_smsnotifier/__init__.py
+++ b/octoprint_smsnotifier/__init__.py
@@ -77,13 +77,17 @@ class SMSNotifierPlugin(octoprint.plugin.EventHandlerPlugin,
                             self._logger.info("Snapshot uploaded to to %s" % (response.json()['data']['img_url']))
                             if self._send_txt(payload, response.json()['data']['img_url']):
                                 return True
-                    self._logger.warn("Could not send a webcam image, sending only text notification.")
-                    self._send_txt(payload)
-            self._logger.warn("Could not get a image from the webcam. Is it enabled?")
-            return False
+                            else:
+                                self._logger.warn("Could not send a webcam image, sending only text notification.")
+                                return self._send_txt(payload)
+                        else:
+                            self._logger.error("Uploads.im returned {} and {}".format(response.status_code, response.status_txt))
+                            return self._send_txt(payload)
+            self._logger.warn("Could not find settings for snapshot URL. Is it enabled?")
+            return self._send_txt(payload)
 
         else:
-            self._send_txt(payload)
+            return self._send_txt(payload)
 
     def _send_txt(self, payload, snapshot=False):
 

--- a/octoprint_smsnotifier/__init__.py
+++ b/octoprint_smsnotifier/__init__.py
@@ -66,7 +66,6 @@ class SMSNotifierPlugin(octoprint.plugin.EventHandlerPlugin,
                     self._logger.info("Processing %s before uploading." % snapshot_path)
                     self._process_snapshot(snapshot_path)
 
-                    image = {"upload": open(snapshot_path, "rb")}
                     try:
                         from cloudinary import uploader
                         response = uploader.unsigned_upload(snapshot_path, "snapshot", cloud_name="octoprint-twilio")

--- a/octoprint_smsnotifier/templates/smsnotifier_settings.jinja2
+++ b/octoprint_smsnotifier/templates/smsnotifier_settings.jinja2
@@ -66,7 +66,7 @@
               <input type="checkbox" data-bind="checked: settings.plugins.smsnotifier.send_image">{{ _('Send picture (camera required)') }}
           </label>
           <span class="help-block"><span class="label label-warning">{{ _('Warning') }}</span>{% trans %}
-              Due to the way Twilio implements <a href="https://www.twilio.com/docs/quickstart/python/sms/sending-via-rest#send-sms-via-api" target="_blank">sending of picture messages</a>. The snapshot from your camera will be hosted <b>publicly</b> at <a href="http://uploads.im" target="_blank">uploads.im</a>.
+              Due to the way Twilio implements <a href="https://www.twilio.com/docs/quickstart/python/sms/sending-via-rest#send-sms-via-api" target="_blank">sending of picture messages</a>. The snapshot from your camera will be hosted <b>publicly</b> at <a href="https://cloudinary.com/" target="_blank">uploads.im</a>.
           {% endtrans %}</span>
       </div>
   </div>

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/anoved/OctoPrint-EmailNotifier"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ['twilio>=6','phonenumbers','requests']
+plugin_requires = ['twilio>=6','phonenumbers','cloudinary',"six>=1.9.0"]
 
 # Additional package data to install for this plugin. The subfolders "templates", "static" and "translations" will
 # already be installed automatically if they exist.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_%s" % plugin_identifier
 plugin_name = "OctoPrint-Twilio"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.2.0"
+plugin_version = "0.3.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Uploads.im is down. Probably for good. Returning 500 with no msg. Not just the API but the website as well. Fixes #6 

I have signed up for a cloudinary free account under the "Octoprint-Twilio" Moniker. I can share the creds with you if you like.

Last time you updated the py package to `0.3.0` but did not set that in `setup.py`. I have the set the version in setup.py to `0.3.1`. 

Thanks,
Levi