### PR TITLE
docfix: 404'ed image

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Recieve SMS notifications when OctoPrint jobs are complete.
 
-![Settings tab and email screenshot](extras/emailnotifier.png)
+![Settings tab and email screenshot](extras/smsnotifier.png)
 
 ## Installation
 


### PR DESCRIPTION
the image link was bad. now it's good.