### PR TITLE
Update __init__.py

### DIFF
--- a/octoprint_smsnotifier/__init__.py
+++ b/octoprint_smsnotifier/__init__.py
@@ -91,7 +91,7 @@ class SMSNotifierPlugin(octoprint.plugin.EventHandlerPlugin,
 
     def _send_txt(self, payload, snapshot=False):
 
-        filename = os.path.basename(payload["file"])
+        filename = payload["name"]
 
         import datetime
         import octoprint.util


### PR DESCRIPTION
payload key "file" deprecated since 1.3.0 and removed in 1.4.0; replaced with "name".