### PR TITLE
Resolved Issue #20 Not sending to Multiple Number

### DIFF
--- a/octoprint_smsnotifier/__init__.py
+++ b/octoprint_smsnotifier/__init__.py
@@ -101,37 +101,34 @@ class SMSNotifierPlugin(octoprint.plugin.EventHandlerPlugin,
 
         for number in self._settings.get(['recipient_number']).split(','):
             tonumber = phonenumbers.format_number(phonenumbers.parse(number, 'US'), phonenumbers.PhoneNumberFormat.E164)
-        tags = {
-            'filename': filename,
-            'elapsed_time': elapsed_time,
-            'printer_name': self._settings.get(["printer_name"])
-        }
-        message = self._settings.get(["message_format", "body"]).format(**tags)
+            tags = {
+                'filename': filename,
+                'elapsed_time': elapsed_time,
+                'printer_name': self._settings.get(["printer_name"])
+            }
+            message = self._settings.get(["message_format", "body"]).format(**tags)
 
-        client = TwilioRestClient(self._settings.get(['account_sid']), self._settings.get(['auth_token']))
-        if snapshot:
-            try:
-                client.messages.create(to=tonumber, from_=fromnumber, body=message, media_url=snapshot)
-            except Exception as e:
-                # report problem sending sms
-                self._logger.exception("SMS notification error: %s" % (str(e)))
-                return False
+            client = TwilioRestClient(self._settings.get(['account_sid']), self._settings.get(['auth_token']))
+            if snapshot:
+                try:
+                    client.messages.create(to=tonumber, from_=fromnumber, body=message, media_url=snapshot)
+                except Exception as e:
+                    # report problem sending sms
+                    self._logger.exception("SMS notification error: %s" % (str(e)))
+                    return False
+                else:
+                    # report notification was sent
+                    self._logger.info("Print notification sent to %s" % (self._settings.get(['recipient_number'])))
             else:
-                # report notification was sent
-                self._logger.info("Print notification sent to %s" % (self._settings.get(['recipient_number'])))
-                return True
-
-        try:
-            client.messages.create(to=tonumber, from_=fromnumber, body=message)
-        except Exception as e:
-            # report problem sending sms
-            self._logger.exception("SMS notification error: %s" % (str(e)))
-        else:
-            # report notification was sent
-            self._logger.info("Print notification sent to %s" % (self._settings.get(['recipient_number'])))
-            return True
-
-        return False
+                try:
+                    client.messages.create(to=tonumber, from_=fromnumber, body=message)
+                except Exception as e:
+                    # report problem sending sms
+                    self._logger.exception("SMS notification error: %s" % (str(e)))
+                    return False
+                else:
+                    # report notification was sent
+                    self._logger.info("Print notification sent to %s" % (self._settings.get(['recipient_number'])))
 
     def _process_snapshot(self, snapshot_path, pixfmt="yuv420p"):
         hflip = self._settings.global_get_boolean(["webcam", "flipH"])


### PR DESCRIPTION
Changes to `_sent_txt` function to cull individual "to" phone numbers separated by commas and loop over sending text message to each one.